### PR TITLE
Ppi 23

### DIFF
--- a/placetmachine/machine.py
+++ b/placetmachine/machine.py
@@ -1487,9 +1487,7 @@ class Machine():
 		---------------------
 		additional_lineskip: int, default 0
 			Can only take the value of '0'. If not given, the default values for the commands are used
-		save_survey: str
-			If given saves the survey to a file with a given name
-		//**// Accepts the parameters for InterGirderMove (see Placet.InterGirderMove), SaveAllPositions (see Placet.SaveAllPositions), 
+		//**// Accepts the parameters for InterGirderMove (see Placet.InterGirderMove) 
 			   and Placet.Clic (see Placet.Clic) //**//
 		"""
 		if extra_params.get('additional_lineskip', 0) != 0:
@@ -1497,10 +1495,6 @@ class Machine():
 
 		self.placet.Clic(**extra_params)
 		self.placet.InterGirderMove(**extra_params)
-
-		if 'save_survey' in extra_params:
-			self.placet.SaveAllPositions(**dict(extra_params, file = extra_params.get('save_survey'), cav_bpm = 1, cav_grad_phas = 1))
-			
 
 	def empty(self, **extra_params):
 		"""Apply the empty function"""

--- a/placetmachine/placet/placetwrap.py
+++ b/placetmachine/placet/placetwrap.py
@@ -1157,7 +1157,7 @@ class Placet(Placetpy):
 			raise Exception("'file' parameter is missing")
 		_options_list = ['file', 'binary', 'nodrift', 'vertical_only', 'positions_only', 'cav_bpm', 'cav_grad_phas']
 		
-		self.run_command(self.__construct_command("SaveAllPositions", _options_list, **command_details))
+		self.run_command(self.__construct_command("SaveAllPositions", _options_list, **dict(command_details, expect_after = True)))
 
 	def ReadAllPositions(self, **command_details):
 		"""
@@ -1503,7 +1503,7 @@ class Placet(Placetpy):
 		additional_lineskip: int
 			The amount of the lines in the output to skip after executing the command
 		"""
-		self.run_command(self.__construct_command("BpmReadings", ['file'], **command_details))
+		self.run_command(self.__construct_command("BpmReadings", ['file'], **dict(command_details, expect_after = True)))
 
 	def MoveGirder(self, **command_details):
 		'''

--- a/placetmachine/placet/pyplacet.py
+++ b/placetmachine/placet/pyplacet.py
@@ -31,7 +31,7 @@ class PlacetCommand():
 	"ElementSetAttributes", "TclCall", "TwissMain"]
 
 	#options that affect the execution/parsing of the commands
-	optional_parameters = ['timeout', 'additional_lineskip', 'no_expect']
+	optional_parameters = ['timeout', 'additional_lineskip', 'expect_after', 'expect_before', 'no_expect']
 
 	def __init__(self, command, **kwargs):
 		"""
@@ -51,15 +51,22 @@ class PlacetCommand():
 			The number of lines of the Placet output to skip after writing the command
 
 			Each command type has its additional_lineskip associated with it. The value passed here will overwrite it.
-
+		
+		expect_before: bool default True
+			If True, expect command is invoked before 'writing' the command.
+		expect_after: bool default False
+			If True, expect command is invoked after 'writing' the command.
 		no_expect: bool default False
-			If True, expect command for the command prompt is not invoked before doing 'write'. Should be used carefully.
+			If True, expect command for the command prompt is not invoked neither before or after doing 'write'.
+			Overwrites 'expect_before' and 'expect_after'.
 		"""
-		self.command = command	
+		self.command = command
 		self.timeout = kwargs.get('timeout', None)
 		self.type = kwargs.get("type") if "type" in kwargs else self._get_command_type(command) 
 		self.additional_lineskip = kwargs.get("additional_lineskip") if "additional_lineskip" in kwargs else self._additional_lineskip(self.type)
 		self.no_expect = kwargs.get('no_expect', False)
+		self.expect_before = kwargs.get('expect_before', True)
+		self.expect_after = kwargs.get('expect_after', False)
 
 	def _additional_lineskip(self, command_type):
 		"""
@@ -113,7 +120,7 @@ class PlacetCommand():
 			raise ValueError("Command " + keyword + " does not exist!")
 
 	def __repr__(self):
-		return f"PlacetCommand({repr(self.command)}, timeout = {self.timeout}, type = '{self.type}', additional_lineskip = {self.additional_lineskip}, no_expect = {self.no_expect})"	
+		return f"PlacetCommand({repr(self.command)}, timeout = {self.timeout}, type = '{self.type}', additional_lineskip = {self.additional_lineskip}, expect_before = {self.expect_before}, expect_after = {self.expect_after}, no_expect = {self.no_expect})"	
 	
 	def __str__(self):
 		return f"PlacetCommand(command = {repr(self.command)})"
@@ -206,7 +213,11 @@ class Placetpy(Communicator):
 		skipline: bool, default True
 			If True invokes skipline() to read the written command from the buffer
 		"""
-		opt = {'no_expect': command.no_expect}
+		opt = {
+			'no_expect': command.no_expect,
+			'expect_before': command.expect_before,
+			'expect_after': command.expect_after
+		}
 		if command.timeout is not None:
 			opt['timeout'] = command.timeout
 


### PR DESCRIPTION
`execution_comfirmation` decorator was removed from Machine. Because of that several commands in Machine stopped working ocasionaly. It is only related to the commands that are used to produce the files that are read with Python afterwards. Functions involved were `BpmReadings` and `SaveAllPositions`. To fix that, we:
1)  Introduced `expect_before` and `expect_after` arguments for `Communicator.writeline()`. Default values are True and False respectively
2) For the commands specified it is invoked, specifying `expect_after = True`.
3) Additional flag was intoduced `__expect_block` in `Communicator` to make sure 1 'expect' is invoked between each 2 commands
4) This changes went up to `PlacetCommand` adding the properties `expect_before` and `expect_after`
