### PR TITLE
PPI 30

### DIFF
--- a/placetmachine/placet/communicator.py
+++ b/placetmachine/placet/communicator.py
@@ -1,12 +1,45 @@
 from functools import wraps
 import json
 import time
-import pexpect
+from abc import ABC, abstractmethod
 import pandas as pd
 from typing import Callable, List
+import pexpect
 
 
-class Communicator:
+def alive_check(func: Callable) -> Callable:
+	"""
+	Decorator that checks if the child process is alive before interacting with it.
+
+	Used with Communicator.writeline(), Communicator._readline(), and Communicator.readlines().
+	"""
+	@wraps(func)
+	def wrapper(self, *args, **kwargs):
+		if self.isalive():
+			return func(self, *args, **kwargs)
+		else:
+			raise Exception(f"The process is dead. Restart it before running '{func.__name__}'.")
+	
+	return wrapper
+
+def logging(func: Callable) -> Callable:
+	"""
+	Decorator that logs the execution of Communicator.writeline(), Communicator.readline(), and Communicator.readlines().
+	"""
+	@wraps(func)
+	def wrapper(self, *args, **kwargs):
+		if self.debug_mode:
+			exec_summ = dict(function = func.__name__, arguments = [args, kwargs])
+			self.debug_data = self.debug_data.append(exec_summ, ignore_index = True)
+			print(f"\t{exec_summ}")
+
+		res = func(self, *args, **kwargs)
+
+		return res
+
+	return wrapper
+
+class Communicator(ABC):
 	"""
 	A class used to interact with the process spawned with Pexpect
 	
@@ -25,16 +58,20 @@ class Communicator:
 		Add the time delay before sending the data to child process
 	save_logs()
 		Create the files for logging the terminal in/out-put
-	readline(timeout = _BASE_TIMEOUT)
-		Read the line received from a child process
-	readlines(N_lines, timeout = _BASE_TIMEOUT)
-		Read several lines received from a child process
-	skipline(timeout = _BASE_TIMEOUT)
-		Same to readline, but no return
 	writeline(command, skipline = True, timeout = _BASE_TIMEOUT)
 		Write the line to a child process
+	isalive()
+		Get the status of the child process
 	close()
-		Finish the runnning processes and terminate the child process
+		Terminate the child procss
+	_readline(timeout = _BASE_TIMEOUT)
+		Read the line received from a child process
+	skipline(timeout = _BASE_TIMEOUT)
+		Same to _readline, but no return
+	readlines(N_lines, timeout = _BASE_TIMEOUT)
+		Read several lines received from a child process
+	flush()
+		Flush the child process buffer
 	save_debug_info(filename = "debug_data.pkl")
 		Save the debug data to a file
 
@@ -47,8 +84,6 @@ class Communicator:
 	__expect_block = False
 	def __init__(self, process_name: str, **kwargs):
 		"""
-		29.11.2022	- New version of the communicator without the daemon running in the background
-
 		Parameters
 		----------
 		process_name: str
@@ -86,43 +121,6 @@ class Communicator:
 			self.close()
 
 		self.__init()
-
-	def logging(func: Callable) -> Callable:
-		"""Log the functions running"""
-		@wraps(func)
-		def wrapper(self, *args, **kwargs):
-			start = time.time()
-			res = func(self, *args, **kwargs)
-			run_time = time.time() - start
-			if self.debug_mode:
-				exec_summ = dict(function = func.__name__, arguments = [args, kwargs], run_time = run_time, res = res)
-				self.debug_data = self.debug_data.append(exec_summ, ignore_index = True)
-				print(json.dumps(exec_summ, indent = 4, sort_keys = True))
-			return res
-
-		@wraps(func)
-		def wrapper_2(self, *args, **kwargs):
-			if self.debug_mode:
-				exec_summ = dict(function = func.__name__, arguments = [args, kwargs])
-				self.debug_data = self.debug_data.append(exec_summ, ignore_index = True)
-				print("\t" + str(exec_summ))
-
-			res = func(self, *args, **kwargs)
-
-			return res
-
-		return wrapper_2
-
-	def alive_check(func: Callable) -> Callable:
-		"""Check if the process is alive before running the function"""
-		@wraps(func)
-		def wrapper(self, *args, **kwargs):
-			if self.isalive():
-				return func(self, *args, **kwargs)
-			else:
-				raise Exception(f"The process is dead. Restart it before running '{func.__name__}'.")
-		
-		return wrapper
 
 	def add_send_delay(self, time: float = _DELAY_BEFORE_SEND):
 		"""Add the time delay before each data transfer"""
@@ -216,42 +214,7 @@ class Communicator:
 
 	@logging
 	@alive_check
-	def skipline(self, timeout: float = _BASE_TIMEOUT):
-		"""
-		Skip the line of the child's process output.
-		
-		Paramaters
-		----------
-		timeout: float, default Communicator._BASE_TIMEOUT
-			Timeout of the reader before raising the exception.
-			[30.11.2022] - No effect anymore. The parameter is kept for compatibility.
-		"""
-		self.readline(timeout)
-
-	def __error_seeker(func: Callable) -> Callable:
-		"""
-		Wrapper for readline().
-
-		Checks if the output does not contain an error.
-
-		If containts "ERROR", throws an exception
-		If containts "WARNING", throws an exception
-		"""
-		@wraps(func)
-		def wrapper(self, timeout: float = None):
-			res = func(self, timeout) if timeout is not None else func(self)
-
-			if "error".casefold() in list(map(lambda x: x.casefold(), res.split())):
-				raise Exception("Process exited with an error message:\n" + res)
-			if "warning".casefold() in list(map(lambda x: x.casefold(), res.split())):
-				raise Exception("Process encountered a warning:\n" + res)
-			return res
-		return wrapper
-
-	@logging
-	@__error_seeker
-	@alive_check
-	def readline(self, timeout = _BASE_TIMEOUT) -> str:
+	def _readline(self, timeout = _BASE_TIMEOUT) -> str:
 		"""
 		Read the line from the child process.
 
@@ -268,6 +231,32 @@ class Communicator:
 		"""
 
 		return self.process.readline()
+	
+	@logging
+	@alive_check
+	def skipline(self, timeout: float = _BASE_TIMEOUT):
+		"""
+		Skip the line of the child's process output.
+		
+		Paramaters
+		----------
+		timeout: float, default Communicator._BASE_TIMEOUT
+			Timeout of the reader before raising the exception.
+			[30.11.2022] - No effect anymore. The parameter is kept for compatibility.
+		"""
+		self._readline(timeout)
+
+	@abstractmethod
+	def readline(self) -> str:
+		"""
+		Read the line from the child process.
+
+		Returns
+		-------
+		str
+			The line of the data received from the child process.
+		"""
+		pass
 
 	@logging
 	@alive_check
@@ -290,7 +279,7 @@ class Communicator:
 		"""
 		res = []
 		for i in range(N_lines):
-			res.append(self.readline(timeout))
+			res.append(self._readline(timeout))
 		return res
 
 	def flush(self):

--- a/placetmachine/placet/placetwrap.py
+++ b/placetmachine/placet/placetwrap.py
@@ -1,9 +1,8 @@
-from placetmachine.placet import Placetpy, PlacetCommand
-
-import pandas as pd
 from functools import wraps
 from time import sleep, time
 from typing import Callable
+import pandas as pd
+from placetmachine.placet import Placetpy, PlacetCommand
 
 
 _extract_subset = lambda _set, _dict: list(filter(lambda key: key in _dict, _set))

--- a/placetmachine/placet/pyplacet.py
+++ b/placetmachine/placet/pyplacet.py
@@ -197,14 +197,13 @@ class Placetpy(Communicator):
 		
 		return wrapper_2
 
-
-
 	@logging
 	def run_command(self, command: PlacetCommand, skipline: bool = True):
 		"""
 		Run the given command in Placet.
 
-		Does not return any value.
+		Does not return any value. 
+		The output after the execution is up to the user to read with Communicator.writeline()
 
 		Parameters
 		----------

--- a/placetmachine/placet/pyplacet.py
+++ b/placetmachine/placet/pyplacet.py
@@ -1,8 +1,7 @@
-from placetmachine.placet import Communicator
-
 import time
 from functools import wraps
 from typing import Callable
+from placetmachine.placet import Communicator
 
 
 class PlacetCommand():
@@ -126,6 +125,44 @@ class PlacetCommand():
 	def __str__(self):
 		return f"PlacetCommand(command = {repr(self.command)})"
 
+def error_seeker(func: Callable) -> Callable:
+	"""
+	Decorator that checks for the words "error"/"warning" in PLACET output
+
+	Checks if the output does not contain an error.
+
+	If containts "ERROR", throws an exception
+	If containts "WARNING", throws an exception
+	"""
+	@wraps(func)
+	def wrapper(self, timeout: float = None):
+		res = func(self, timeout) if timeout is not None else func(self)
+
+		if "error".casefold() in list(map(lambda x: x.casefold(), res.split())):
+			self.process.close()
+			raise Exception("Process exited with an error message:\n" + res)
+		if "warning".casefold() in list(map(lambda x: x.casefold(), res.split())):
+			self.process.close()
+			raise Exception("Process encountered a warning:\n" + res)
+		return res
+	return wrapper
+
+def logging(func: Callable) -> Callable:
+	"""Logging decorator used, when debug mode is on"""
+	@wraps(func)
+	def wrapper(self, *args, **kwargs):
+		if self.debug_mode:
+			exec_summ = dict(function = func.__name__, arguments = [args, kwargs])
+			print(exec_summ)
+			self.debug_data = self.debug_data.append(exec_summ, ignore_index = True)
+#				print(json.dumps(exec_summ, indent = 4, sort_keys = True))
+
+		res = func(self, *args, **kwargs)
+		
+		return res
+	
+	return wrapper
+
 class Placetpy(Communicator):	
 	"""
 	A class used to interact with Placet process running in background
@@ -150,7 +187,12 @@ class Placetpy(Communicator):
 		---------------------
 		show_intro: bool default True
 			If True, prints the welcome message of Placet at the start
-		//**//Accepts all the additional parameters that Communicator accepts (Check Communicator) //**//
+		debug_mode: bool, default False
+			If True, runs Communicator in debug mode
+		save_logs: bool, default True
+			If True, invoking save_debug_info()
+		send_delay: float, default Communicator._BUFFER_MAXSIZE
+			The time delay before each data transfer to a child process (sometimes needed for stability)
 		
 		"""
 		super(Placetpy, self).__init__(name, **kwargs)
@@ -170,32 +212,23 @@ class Placetpy(Communicator):
 		self._restart()
 		self.__read_intro()
 
-	def logging(func: Callable) -> Callable:
-		"""Logging decorator used, when debug mode is on"""
-		@wraps(func)
-		def wrapper(self, *args, **kwargs):
-			start = time.time()
-			res = func(self, *args, **kwargs)
-			run_time = time.time() - start
-			if self.debug_mode:
-				exec_summ = dict(function = func.__name__, arguments = [args, kwargs], run_time = run_time, res = res)
-				self.debug_data = self.debug_data.append(exec_summ, ignore_index = True)
-				print(exec_summ)
-			return res
-		
-		@wraps(func)
-		def wrapper_2(self, *args, **kwargs):
-			if self.debug_mode:
-				exec_summ = dict(function = func.__name__, arguments = [args, kwargs])
-				print(exec_summ)
-				self.debug_data = self.debug_data.append(exec_summ, ignore_index = True)
-#				print(json.dumps(exec_summ, indent = 4, sort_keys = True))
+	@error_seeker
+	def readline(self, timeout = Communicator._BASE_TIMEOUT):
+		"""
+		Read the line from PLACET process.
 
-			res = func(self, *args, **kwargs)
-			
-			return res
-		
-		return wrapper_2
+		Parameters
+		----------
+		timeout: float, default Communicator._BASE_TIMEOUT
+			Timeout of the reader before raising the exception.
+			[30.11.2022] - No effect anymore. The parameter is kept for compatibility.
+
+		Returns
+		-------
+		str
+			The line of the data received from the child process.
+		"""
+		return self._readline()
 
 	@logging
 	def run_command(self, command: PlacetCommand, skipline: bool = True):


### PR DESCRIPTION
Here is the list of some changes:

- Communicator was made an abstract class. It does not hold any relation to PLACET. + some code restructuring.

- The `__error_seeker()` decorator was removed from Communicator.

- Method `readline()` was made an abstract method. The same functionality as the previous version is hold by `_readline()`.

- Method `readline()` was added to `Placetpy` and is decorated with `error_seeker` decorator (same one as `__error_seeker()` in the old version)

- Some code restructuring in `Placetpy`.