### PR TITLE
PPI 129

### DIFF
--- a/placetmachine/lattice/knob.py
+++ b/placetmachine/lattice/knob.py
@@ -78,7 +78,8 @@ class Knob:
 		self.mismatch, self.changes = [0.0] * len(elements), [0.0] * len(elements)
 		self.amplitude_mismatch = 0.0
 		self.name, self.step_size = extra_params.get('name', ""), extra_params.get('step_size', None)
-		
+		self.coord = coord
+
 		# checking the supported types and building the types involved
 		for element in self.elements:
 			if element.type not in self._accepted_types:
@@ -87,14 +88,17 @@ class Knob:
 			if element.type not in self.types_of_elements:
 				self.types_of_elements.append(element.type)
 		
-		self.coord = coord
+			# storing the info about mismatches
+			if not hasattr(element, '_mismatch'):
+				element._mismatch = {self.coord: 0.0}
+		
 		if self.coord not in self._cached_parameters:
 			raise ValueError(f"Incorrect coordinate. Acceptable are {self._cached_parameters}, received '{coord}'")
 
 		self.values = values
 		if len(self.values) != len(self.elements):
 			raise ValueError(f"The number of elements and values provided are different.")
-	
+
 	def reset(self):
 		"""
 		Reset the knob's data.
@@ -114,12 +118,12 @@ class Knob:
 
 		Amplitude defines the fraction of `values` to add to the `elements`s `coord` involved in 
 		the `Knob`. If `step_size` is not defined (default), coordinates changes are applied directly.
-		If `step_size` is defined, the values of the coordinates' changes are rounded to the closest
-		value that has a full number of `step_size`s. 
+		If `step_size` is defined, the actual coordinates' changes will be different from the ones defined
+		by attribute `values`. This difference also depends on the `strategy` used.
 
 		Parameters
 		----------
-		amplitude : float
+		amplitude
 			Amplitude of the knob to apply.
 
 		Other parameters
@@ -127,6 +131,12 @@ class Knob:
 		strategy : str
 			Strategy to use for calculations of the offsets when the `step_size` is defined. Default is
 			'simple_memory'.
+		use_global_mismatch : bool
+			If `True` (default) coordinates' changes are evaluated to also compensate the possible mismatches
+			caused by other knobs. Only applicable to the strategies that memorize the mismatches, such as:
+			```
+			['simple_memory', 'min_scale_memory']
+			```
 		"""
 		
 
@@ -146,11 +156,11 @@ class Knob:
 			if strategy == "simple":
 				self.__appply_simple(amplitude)
 			if strategy == "simple_memory":
-				self.__apply_simple_memory(amplitude)
+				self.__apply_simple_memory(amplitude, use_global_mismatch = kwargs.get('use_global_mismatch', True))
 			if strategy == "min_scale":
 				self.__apply_min_scale(amplitude)
 			if strategy == "min_scale_memory":
-				self.__apply_min_scale_memory(amplitude)
+				self.__apply_min_scale_memory(amplitude, use_global_mismatch = kwargs.get('use_global_mismatch', True))
 
 	def cache_state(self):
 		"""
@@ -193,6 +203,7 @@ class Knob:
 		
 		for i, element in enumerate(self.elements):
 			element[self.coord] += self._cached_data['changes'][i] - self.changes[i]
+			element._mismatch[self.coord] += self._cached_data['mismatch'][i] - self.mismatch[i]
 
 		self.amplitude = self._cached_data['amplitude']
 		self.amplitude_mismatch = self._cached_data['amplitude_mismatch']
@@ -228,13 +239,18 @@ class Knob:
 					new_coord_change = (n_step_sizes - 1) * self.step_size
 
 			self.changes[i] += new_coord_change
+
+			old_mismatch = self.mismatch[i]
 			self.mismatch[i] = self.values[i] * (self.amplitude + amplitude) - self.changes[i]
+
+			# mismatch is accumulated with respect to the individual elements
+			element._mismatch[self.coord] += self.mismatch[i] - old_mismatch
 
 			element[self.coord] += new_coord_change
 		
 		self.amplitude += amplitude
 
-	def __apply_simple_memory(self, amplitude):
+	def __apply_simple_memory(self, amplitude: float, **extra_params):
 		"""
 		Apply the the knob.
 
@@ -243,11 +259,19 @@ class Knob:
 
 		Parameters
 		----------
-		amplitude : float
+		amplitude
 			Amplitude of the knob to apply.
+
+		Other parameters
+		----------------
+		use_global_mismatch : bool
+			If `True` (default) coordinates' changes are evaluated to also compensate the possible mismatches
+			caused by other knobs.
 		"""
 		for i, element in enumerate(self.elements):
-			coord_change = self.values[i] * amplitude + self.mismatch[i]
+			coord_change = self.values[i] * amplitude
+			coord_change += element._mismatch[self.coord] if extra_params.get('use_global_mismatch', True) else self.mismatch[i]
+
 			n_step_sizes = int(coord_change / self.step_size)
 			
 			new_coord_change = None
@@ -261,7 +285,11 @@ class Knob:
 
 			self.changes[i] += new_coord_change
 
+			old_mismatch = self.mismatch[i]
 			self.mismatch[i] = self.values[i] * (self.amplitude + amplitude) - self.changes[i]
+
+			# mismatch is accumulated with respect to the individual elements
+			element._mismatch[self.coord] += self.mismatch[i] - old_mismatch
 
 			element[self.coord] += new_coord_change
 		
@@ -308,6 +336,8 @@ class Knob:
 			if i == i_min:
 				self.changes[i] += ref_offset
 				self.mismatch[i] = self.values[i] * (self.amplitude + amplitude_adjusted) - self.changes[i]
+
+				element._mismatch[self.coord] += self.mismatch[i]
 				element[self.coord] += ref_offset
 				continue
 
@@ -421,6 +451,7 @@ class Knob:
 			Knob data summary
 		"""
 		data_dict = {key: [] for key in ['name', 'type', 'girder', 's'] + [self.coord + "_amplitude", self.coord + "_current"]}
+		total_mismatch = []
 		for i, element in enumerate(self.elements):
 			data_dict['name'].append(element['name'])
 			
@@ -432,8 +463,11 @@ class Knob:
 			data_dict[self.coord + "_amplitude"].append(self.values[i])
 			data_dict[self.coord + "_current"].append(element[self.coord])
 
-		data_dict[self.coord + "_changes"] = self.changes
-		data_dict[self.coord + "_mismatch"] = self.mismatch
+			total_mismatch.append(element._mismatch[self.coord])
+
+		data_dict[f"{self.coord}_changes"] = self.changes
+		data_dict[f"{self.coord}_mismatch"] = self.mismatch
+		data_dict[f"{self.coord}_total_mismatch"] = total_mismatch
 
 		return DataFrame(data_dict)
 

--- a/tests/lattice/test_knob.py
+++ b/tests/lattice/test_knob.py
@@ -60,7 +60,7 @@ class KnobTest(unittest.TestCase):
 		# offsets = 1.5, 0.75
 		# applied 2.0, 1.0 | missmatch -0.5, -0.25
 
-		print(knob)
+#		print(knob)
 
 		self.assertEqual(self.test_quad['y'], 2.0)
 		self.assertEqual(knob.mismatch, [-0.5, -0.25])
@@ -68,7 +68,7 @@ class KnobTest(unittest.TestCase):
 		knob.apply(0.5, strategy = "simple_memory", use_global_mismatch = False)
 		# offsets = 1.5, 0.75
 		# applied 1.0 (3.0), 1.0(2.0) | missmatch 0.0, -0.5
-		print(knob)
+#		print(knob)
 		self.assertEqual(self.test_quad['y'], 3.0)
 		self.assertEqual(knob.mismatch, [0.0, -0.5])
 		self.assertEqual(second_quad['y'], 2.0)
@@ -76,7 +76,7 @@ class KnobTest(unittest.TestCase):
 		knob.apply(1.0, strategy = "simple_memory", use_global_mismatch = False)
 		# offsets = 3.0, 1.5
 		# applied 3.0(6.0), 1.0(2.0) | mismatch 0.0, 0.0
-		print(knob)
+#		print(knob)
 		self.assertEqual(knob.mismatch, [0.0, 0.0])
 
 	def test_apply2_2(self):
@@ -90,7 +90,7 @@ class KnobTest(unittest.TestCase):
 		# offsets = 1.5, 0.75
 		# applied 2.0, 1.0 | missmatch -0.5, -0.25 | global_mismatch -0.5, -0.25
 
-		print(knob)
+#		print(knob)
 
 		second_knob.apply(2.0, strategy = "simple_memory", use_global_mismatch = False)
 		# offset = 0.8
@@ -99,7 +99,7 @@ class KnobTest(unittest.TestCase):
 		self.assertEqual(self.test_quad._mismatch['y'], -0.7)
 		self.assertEqual(second_quad._mismatch['y'], -0.25)
 
-		print(second_knob)
+#		print(second_knob)
 
 	def test_apply2_3(self):
 		second_quad = Quadrupole({'name': "test_quad2"})
@@ -112,14 +112,14 @@ class KnobTest(unittest.TestCase):
 		# offsets = 1.5, 0.75
 		# applied 2.0, 1.0 | missmatch -0.5, -0.25 | global_mismatch -0.5, -0.25
 
-		print(knob)
+#		print(knob)
 
 		second_knob.apply(2.0, strategy = "simple_memory", use_global_mismatch = True)
 		# offset = 1.4
 		# with global mismatch 0.9 
 		# applied 1.0 | mismatch 0.4 (global mismatch is not taken into account here)
 		# global mismatch -0.1 (-0.5 + 0.4)
-		print(second_knob)
+#		print(second_knob)
 
 		self.assertAlmostEqual(self.test_quad._mismatch['y'], -0.1)
 		self.assertAlmostEqual(second_knob.mismatch[0], 0.4)
@@ -171,8 +171,8 @@ class KnobTest(unittest.TestCase):
 		# applied 0.0, 0.0 | mismatch 0.0, 0.0 | amplitude change 0.25 -> 0.0
 		self.assertAlmostEqual(knob.amplitude, 2./3., delta = 1e-4)
 
-		print(knob)
-		print(knob.amplitude)
+#		print(knob)
+#		print(knob.amplitude)
 
 	def test_apply5(self):
 		
@@ -188,8 +188,8 @@ class KnobTest(unittest.TestCase):
 		self.assertAlmostEqual(self.test_quad['y'], 2.0)
 		self.assertAlmostEqual(knob.amplitude, 2./3.)
 		
-		print(knob)
-		print(knob.amplitude)
+#		print(knob)
+#		print(knob.amplitude)
 
 		knob.apply(1.0, strategy = "min_scale")
 		# offrsets = 3.25, 1.5
@@ -199,10 +199,57 @@ class KnobTest(unittest.TestCase):
 		self.assertEqual(knob.amplitude, 2.0)
 		self.assertAlmostEqual(self.test_quad['y'], 6.0)
 		self.assertAlmostEqual(second_quad['y'], 3.0)
-		self.assertEqual(knob.mismatch, [0.5, 0.0])
+		self.assertAlmostEqual(knob.mismatch[0], 0.5)
+		self.assertAlmostEqual(knob.mismatch[1], 0.0)
 
-		print(knob)
-		print(knob.amplitude)
+#		print(knob)
+#		print(knob.amplitude)
+
+	def test_apply5_2(self):
+		
+		second_quad = Quadrupole({'name': "test_quad2"})
+
+		knob = Knob([self.test_quad, second_quad], 'y', [3.25, 1.5], step_size = 1.0)
+
+		second_knob = Knob([self.test_quad, second_quad], 'y', [0.7, 1.2], step_size = 1.0)
+		
+		knob.apply(0.5, strategy = "min_scale")
+		# offrsets = 1.625, 0.75
+		# amplitude adjustment to have .., 1.0: 0.5 -> 0.666
+		# applied 2.0 (correct 2.1666..), 1.0 (correct 1.0) | mismatch 0.166.., 0.0
+
+		self.assertEqual(second_quad['y'], 1.0)
+		self.assertAlmostEqual(self.test_quad['y'], 2.0)
+		self.assertAlmostEqual(knob.amplitude, 2./3.)
+		
+#		print(knob)
+#		print(knob.amplitude)
+
+		knob.apply(1.0, strategy = "min_scale")
+		# offrsets = 3.25, 1.5
+		# amplitude adjustment to have .., 2.0: 1.0 -> 1.3333
+		# applied 4.0 (correct 4.333..), 2.0 (correct 2.0)
+		# mismatch 0.33.., 0.0 
+		# total mismatch 0.5 ,0.0
+		# total applied 6.0, 3.0
+		# Total amplitude 2.0
+		# global mismatch 0.5, 0.0
+
+#		print(knob)
+		self.assertAlmostEqual(self.test_quad._mismatch['y'], 0.5)
+		self.assertAlmostEqual(second_quad._mismatch['y'], 0.0)
+
+		second_knob.apply(1.0, strategy = "min_scale")
+		# offsets = 0.7, 1.2
+		# amplitude adjustment to have 1.0: 1.0 -> 1.4286
+		# applied 1.0 (correct 1.0), 2.0 (correct 1.7143)
+		# mismatch 0.0, -0.2857
+		# total mismatch 0.0, -0.2857
+		# global mismatch 0.5, -0.2857
+		
+#		print(second_knob)
+		self.assertAlmostEqual(second_quad._mismatch['y'], 1.2 * 1.0 / 0.7 - 2.0)
+		self.assertAlmostEqual(self.test_quad._mismatch['y'], 0.5)
 
 	def test_apply6(self):
 		
@@ -210,23 +257,83 @@ class KnobTest(unittest.TestCase):
 
 		knob = Knob([self.test_quad, second_quad], 'y', [3.25, 1.5], step_size = 1.0)
 		
-		knob.apply(0.5, strategy = "min_scale_memory")
+		knob.apply(0.5, strategy = "min_scale_memory", use_global_mismatch = False)
 		# offrsets = 1.625, 0.75
-		# applied 2.0 (correct 2.1666..), 1.0 (correct 1.0) | mismatch 0.166.., 0.0 
-		# Amplitude change 0.5 -> 0.6666 | Amplitude mismatch -0.1666
+		# AMplitude
+		# Amplitude adjustment to have a full step size for second element is 1.0 / 1.5 = 0.6(6)
+		# Amplitude mismatch: 0.5 + 0.0 - 0.6(6) = -0.1(6)
+		# Offsets to apply are 2.1(6), 1.0 | Mismatch is 0.0, 0.0
+		# Rounding to 2.0, 1.0 |Produced mismatch 0.1(6), 0.0 
+
+		self.assertEqual(second_quad['y'], 1.0)
+		self.assertAlmostEqual(self.test_quad['y'], 2.0)
+		self.assertAlmostEqual(knob.amplitude, 2./3.)
+		self.assertAlmostEqual(knob.amplitude_mismatch, 0.5 - 2./3.)
+		
+#		print(knob)
+#		print(knob.amplitude)
+#		print(knob.amplitude_mismatch)
+
+		knob.apply(1.0, strategy = "min_scale_memory", use_global_mismatch = False)
+		# amplitude to apply 1.0. Current mismatch is -0.1(6) -> 0.8(3)
+		# This yields offsets:
+		# 2.70833, 1.25
+		# Amplutude adjustment ->  1.0 / 1.5 = 0.6(6)
+		# Amplitude mismatch 1.0 - 0.1(6) - 0.6(6) = 0.1(6)
+		# Offsets to apply: 2.1(6), 1.0. Mismatch is 0.1(6), 0.0
+		# Final values are  2.3(3), 1.0
+		# Rounding to 2.0, 1.0 | New mismatch is 0.3, 0.0
+		# Total applied 4.0, 2.0 | Total amplitude 1.3333
+
+		self.assertAlmostEqual(knob.amplitude, 4./3.)
+		self.assertAlmostEqual(self.test_quad['y'], 4.0)
+		self.assertAlmostEqual(second_quad['y'], 2.0)
+		self.assertAlmostEqual(knob.mismatch[0], 1./3.)
+		self.assertAlmostEqual(knob.mismatch[1], 0.0)
+		self.assertAlmostEqual(knob.amplitude_mismatch, 2./3. - 0.5)
+
+#		print(knob)
+#		print(knob.amplitude)
+#		print(knob.amplitude_mismatch)
+
+		with self.assertRaises(ValueError):
+			knob.apply(2.5, strategy = "custom")
+
+	def test_apply6_2(self):
+		
+		second_quad = Quadrupole({'name': "test_quad2"})
+
+		knob = Knob([self.test_quad, second_quad], 'y', [3.25, 1.5], step_size = 1.0)
+
+		second_knob = Knob([self.test_quad, second_quad], 'y', [1.2, 3.5], step_size = 1.0)
+		
+		knob.apply(0.5, strategy = "min_scale_memory", use_global_mismatch = True)
+		# offrsets = 1.625, 0.75
+		# AMplitude
+		# Amplitude adjustment to have a full step size for second element is 1.0 / 1.5 = 0.6(6)
+		# Amplitude mismatch: 0.5 + 0.0 - 0.6(6) = -0.1(6)
+		# Offsets to apply are 2.1(6), 1.0 | Global mismatch is 0.0, 0.0
+		# Rounding to 2.0, 1.0 | Produced mismatch 0.1(6), 0.0
+		# Produced global mismatch is 0.1(6), 0.0
 
 		self.assertEqual(second_quad['y'], 1.0)
 		self.assertAlmostEqual(self.test_quad['y'], 2.0)
 		self.assertAlmostEqual(knob.amplitude, 2./3.)
 		
-		print(knob)
-		print(knob.amplitude)
+#		print(knob)
+#		print(knob.amplitude)
 
-		knob.apply(1.0, strategy = "min_scale_memory")
-		# amplitude to apply 0.8333333 (mismatch = -0.1666)
-		# offrsets = 2.7083, 1.25
-		# applied 2.0 (correct 2.1667.. + 0.166 (memory)), 1.0 (correct 1.0) | mismatch 0.3333, 0.0 | Amplitude change 1.0 -> 0.8333333
-		# total applied 4.0, 2.0 | Total amplitude 1.3333
+		knob.apply(1.0, strategy = "min_scale_memory", use_global_mismatch = True)
+		# amplitude to apply 1.0. Current mismatch is -0.1(6) -> 0.8(3)
+		# This yields offsets:
+		# 2.70833, 1.25
+		# Amplutude adjustment ->  1.0 / 1.5 = 0.6(6)
+		# Amplitude mismatch 1.0 - 0.1(6) - 0.6(6) = 0.1(6)
+		# Offsets to apply: 2.1(6), 1.0. Gloabal mismatch is 0.1(6), 0.0
+		# Final values are  2.3(3), 1.0
+		# Rounding to 2.0, 1.0 | New  global mismatch is 0.3, 0.0
+		# New mismatch is 0.3(3), 0.0
+		# Total applied 4.0, 2.0 | Total amplitude 1.3333
 
 		self.assertAlmostEqual(knob.amplitude, 4./3.)
 		self.assertAlmostEqual(self.test_quad['y'], 4.0)
@@ -234,8 +341,24 @@ class KnobTest(unittest.TestCase):
 		self.assertAlmostEqual(knob.mismatch[0], 1./3.)
 		self.assertAlmostEqual(knob.mismatch[1], 0.0)
 
-		print(knob)
-		print(knob.amplitude)
+#		print(knob)
+#		print(knob.amplitude)
+
+		second_knob.apply(1.0, strategy = "min_scale_memory", use_global_mismatch = True)
+		# Amplitude to apply 1.0 | No mismatch
+		# Offsets to apply 1.2, 3.5
+		# Amplitude adjustment 1.0 / 1.2 = 0.8(3)
+		# Amplitude mismatch 1.0 + 0.0 - 0.8(3) = 0.1(6)
+		# Offsets to appl 1.0, 2.91(6) | Global mismatch is 0.3(3), 0.0
+		# Final values are 1.3(3), 2.91(6)
+		# That rounds to 1.0, 3.0 | New global mismatch 0.3(3), -0.083(3)
+		# New mismatch is 0.0, -0.083(3)
+
+		self.assertAlmostEqual(self.test_quad._mismatch['y'], 1./3.)
+		self.assertAlmostEqual(second_quad._mismatch['y'], -(3.0 - 1.0 / 1.2 * 3.5))
+
+#		print(second_knob)
+#		print(second_knob.amplitude)
 
 		with self.assertRaises(ValueError):
 			knob.apply(2.5, strategy = "custom")
@@ -249,7 +372,7 @@ class KnobTest(unittest.TestCase):
 		knob.apply(0.5, strategy = "simple")
 		# offrsets = -1.6, 0.75
 		# applied -2.0 , 1.0 | mismatch 0.4, -0.25
-		print(knob)
+#		print(knob)
 		self.assertAlmostEqual(knob.mismatch[0], 0.4, delta = 1e-4)
 		self.assertAlmostEqual(knob.mismatch[1], -0.25, delta = 1e-4)
 
@@ -261,17 +384,17 @@ class KnobTest(unittest.TestCase):
 
 		knob.apply(0.5, strategy = "min_scale_memory")
 
-		print(knob)
-		print(knob.amplitude)
+#		print(knob)
+#		print(knob.amplitude)
 
 		knob.cache_state()
-		print(knob._cached_data)
+#		print(knob._cached_data)
 
 		knob.apply(1.0, strategy = "min_scale_memory")
 
-		print(knob)
-		print(knob.amplitude)
-		print(knob._cached_data)
+#		print(knob)
+#		print(knob.amplitude)
+#		print(knob._cached_data)
 
 		self.assertAlmostEqual(knob._cached_data['amplitude'], 2./3.)
 		self.assertEqual(knob._cached_data['changes'], [2.0, 1.0])
@@ -285,9 +408,9 @@ class KnobTest(unittest.TestCase):
 		self.assertEqual(knob.elements[0]['y'], 0.0)
 		self.assertEqual(knob.elements[1]['y'], 0.0)
 
-		print(knob)
-		print(knob.amplitude)
-		print(knob._cached_data)
+#		print(knob)
+#		print(knob.amplitude)
+#		print(knob._cached_data)
 
 		knob.upload_state_from_cache(True)
 
@@ -296,9 +419,9 @@ class KnobTest(unittest.TestCase):
 		self.assertAlmostEqual(knob.amplitude, 2./3.)
 		self.assertEqual(knob.changes, [2.0, 1.0])
 
-		print(knob)
-		print(knob.amplitude)
-		print(knob._cached_data)
+#		print(knob)
+#		print(knob.amplitude)
+#		print(knob._cached_data)
 
 	def test_to_dataframe(self):
 
@@ -318,5 +441,5 @@ class KnobTest(unittest.TestCase):
 			'y_total_mismatch': [0.0]
 			}
 		test_dataframe = pd.DataFrame(test_dataframe_dict)
-		print(knob.to_dataframe())
+#		print(knob.to_dataframe())
 		pd.testing.assert_frame_equal(test_dataframe, knob.to_dataframe())


### PR DESCRIPTION
- Added the attribute `_mismatch` to the elements that belong to the knobs.
- Added a flag to some strategies, such as `simple_memory` and `min_scale_memory` to use global elements' mismatches when evaluating offsets.
- Fixed the implementation of `min_scale_memory` that was not properly written before.